### PR TITLE
Added historical pricing model change for AWS Config

### DIFF
--- a/archive.md
+++ b/archive.md
@@ -3,6 +3,7 @@ After items are a month old, they'll be moved to this page, to archive them.
 | Date taking effect | Date announced | Service | Change | How to check |
 | ---- | ---- |---- |---- |---- |
 | Nov 29, 2018 | Nov 29, 2018 | Route53 | Price increase by taking a free service of Route53 and renaming to Cloud Map where it then started charging for it. ([link](https://twitter.com/0xdabbad00/status/1068197705594228736)) | |
+| Aug 1, 2019 | May 21, 2019 | Config | Price increase by changing pricing model from per-rule to per-rule evaluation. ([link](https://aws.amazon.com/about-aws/whats-new/2019/05/announcing-the-new-pricing-plan-for-aws-config-rules/)) | |
 | May 30, 2019 | Unknown | Lambda | Support ends for runtime .NET Core 2.0; no longer able to update ([link](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html)) | ``aws lambda list-functions --query 'Functions[?Runtime == `dotnetcore2.0`]'.FunctionName`` |
 | June 1, 2019 | March 25, 2019 | Mechanical Turk | Older versions of the MTurk Requester API (2014-08-15) will stop working ([link](https://forums.aws.amazon.com/ann.jspa?annID=6686)) |  | 
 | June 11, 2019 | May 14, 2019 | Lambda | Execution environment update to Amazon Linux 2018.03 ([link](https://aws.amazon.com/blogs/compute/upcoming-updates-to-the-aws-lambda-execution-environment/)) | See link |


### PR DESCRIPTION
I noticed that there are a couple of price hikes listed in the breaking changes - so I included an old change to the AWS Config pricing model.