### PR TITLE
Add AWS GovCloud (US) RDS CA Certificate Rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This list will also keep track of increases in prices.  This will not track chan
 | Date taking effect | Date announced | Service | Change | How to check |
 | ---- | ---- |---- |---- |---- | 
 | April 29, 2022 | May 14, 2021 | S3 | S3 BitTorrent support to be turned off for customers who have it enabled in their account ([link](https://github.com/awsdocs/amazon-s3-userguide/commit/0d1759880ccb1818ab0f14129ba1321c519d2ac1#diff-72be9d82d9be9bda6a297a4fbd11aca66ecde97e4f90de6f86bdf95c5f6b72c0R3)) | |
+| May 18, 2022 | Dec 30, 2021 | RDS, Aurora (GovCloud) | Database connections that use TLS certificate validation must use the new `rds-ca-rsa4096-g1` CA certificate or connections will fail. Starting March 21, all new databases will use the new CA certificate; starting May 18, all databases will starting having certificate rotations scheduled during their maintenance window. |  |
 | August 15, 2022 | July 28, 2021 | EC2 | EC2 classic retiring ([link](https://aws.amazon.com/blogs/aws/ec2-classic-is-retiring-heres-how-to-prepare/)) | |
 | July 31, 2022 | July 29, 2021 | Console | IE 11 support ending for console ([link](https://aws.amazon.com/blogs/aws/heads-up-aws-support-for-internet-explorer-11-is-ending/)) | |
 | December 31, 2022 | Unknown | EC2 | Spot blocks (defined duration) are no longer supported ([docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances), [api](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html)) | |


### PR DESCRIPTION
The AWS GovCloud RDS CA Certificates expire on May 18. In December, AWS
sent emails to customers using RDS in this partition informing them of
the coming change. There don't seem to be the same volume of
documentation and blog posts that were done when this change was made in
the commercial partition. The change is also referenced on the AWS
GovCloud (US) documentation for Amazon RDS but only as a way it differs
from the other regions.

If there's a good way to do so, I am happy to provide the content of the
email from AWS.
