### PR TITLE
Remove outdated note on OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use one of these services and need to know when AWS will stop supporting 
 * [EKS Kubernetes release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
 * [Lambda supported runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) (major versions for all languages)
 * [Lambda runtime updates](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html) (info to control patch versions)
-* [OpenSearch Service: Supported versions of OpenSearch and Elasticsearch](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version) (as of October 2024, no lifecycle calendar)
+* [OpenSearch Service: Supported versions of OpenSearch and Elasticsearch](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version)
 * [RDS Aurora Versions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.VersionPolicy.html)
 * [RDS Db2 Versions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Db2.Concepts.VersionMgmt.html)
 * [RDS MariaDB Versions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html)


### PR DESCRIPTION
Today the OpenSearch Developer Guide shows an end of support schedule.

![image](https://github.com/user-attachments/assets/03e48fd6-4f36-4885-9323-afeda1a7a169)
